### PR TITLE
fix the random git keyword typo

### DIFF
--- a/app/Http/Livewire/AppTasks.php
+++ b/app/Http/Livewire/AppTasks.php
@@ -18,4 +18,4 @@ class AppTasks extends Component
             'tasks' => $tasks
         ]);
     }
-git}
+}


### PR DESCRIPTION
the random git keyword typo before the last closing bracket is generating an error when creating a new project and removing it fixes the issue